### PR TITLE
Set supportsDenormalization on FieldResponseNormalizer

### DIFF
--- a/src/B2bCode/Bundle/CmsFormBundle/ImportExport/Serializer/FieldResponseNormalizer.php
+++ b/src/B2bCode/Bundle/CmsFormBundle/ImportExport/Serializer/FieldResponseNormalizer.php
@@ -39,4 +39,12 @@ class FieldResponseNormalizer extends ConfigurableEntityNormalizer
 
         return $result;
     }
+    
+     /**
+     * {@inheritdoc}
+     */
+    public function supportsDenormalization($data, $type, $format = null, array $context = [])
+    {
+        return $type === CmsFieldResponse::class;
+    }
 }


### PR DESCRIPTION
Not sure if this class should support denormalization, but without it set to false / support only CmsFieldResponse, it breaks product import (additional units are not being imported).